### PR TITLE
Fix 'loading services' spinner not being hidden if there are none

### DIFF
--- a/src/main/webapp/src/app/service/service.overview.comp.ts
+++ b/src/main/webapp/src/app/service/service.overview.comp.ts
@@ -42,7 +42,8 @@ export class ServiceOverview implements OnInit {
   }
 
   private loadData() {
-    this.serviceHttp.getServices().flatMap(services => {
+    this.serviceHttp.getServices()
+    .flatMap(services => {
       this.services = services;
 
       const usageOps: Observable<ServiceUsage>[] = services.map(service => this.serviceHttp.getServiceUsage(service.name));
@@ -55,13 +56,13 @@ export class ServiceOverview implements OnInit {
         return servicesWithUsage;
       });
     })
+    .finally(() => this.servicesLoaded = true)
     .subscribe(
       (services) => {
         this.services = services;
-        this.servicesLoaded = true;
       }, (err) => {
         this.alerts.danger('Error loading services!');
-        this.servicesLoaded = true;
+        console.error(err);
       }
     );
   }

--- a/src/main/webapp/src/rxjs-extensions.ts
+++ b/src/main/webapp/src/rxjs-extensions.ts
@@ -16,6 +16,7 @@ import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/finally';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/toPromise';


### PR DESCRIPTION
Handle situation where forkJoin Observable completes immediately.