### PR TITLE
Fix connections not being closed in HTTPProvider and RPMIndexer

### DIFF
--- a/src/main/java/de/cinovo/cloudconductor/server/repo/indexer/RPMIndexer.java
+++ b/src/main/java/de/cinovo/cloudconductor/server/repo/indexer/RPMIndexer.java
@@ -38,7 +38,8 @@ public class RPMIndexer implements IRepoIndexer {
 	public Set<PackageVersion> getRepoIndex(IRepoProvider provider) {
 		RepoEntry entry = provider.getEntry(RPMIndexer.REPO_INDEX);
 		if(entry != null) {
-			Document repoXML = this.xmlDOM(provider.getEntryStream(RPMIndexer.REPO_INDEX));
+			InputStream inputStream = provider.getEntryStream(RPMIndexer.REPO_INDEX);
+			Document repoXML = this.xmlDOM(inputStream);
 			XPath xpath = XPathFactory.newInstance().newXPath();
 			try {
 				String primaryHREF = xpath.evaluate("/repomd/data[@type='primary']/location/@href", repoXML);
@@ -50,6 +51,14 @@ public class RPMIndexer implements IRepoIndexer {
 				throw new RuntimeException("Failed to parse repomd.xml", e);
 			} catch(IOException e) {
 				throw new RuntimeException("Failed to read repodata", e);
+			} finally {
+				try {
+					if (inputStream != null) {
+						inputStream.close();
+					}
+				} catch (IOException e) {
+					// don't care
+				}
 			}
 		}
 		return null;

--- a/src/main/java/de/cinovo/cloudconductor/server/repo/provider/HTTPProvider.java
+++ b/src/main/java/de/cinovo/cloudconductor/server/repo/provider/HTTPProvider.java
@@ -53,15 +53,16 @@ public class HTTPProvider implements IRepoProvider {
 	@Override
 	public RepoEntry getEntry(String key) {
 		if ((this.mirror != null) && (this.mirror.getBasePath() != null)) {
-			HTTPResponse response = WS.url(this.getUrl(key)).get();
-			RepoEntry e = new RepoEntry();
-			e.setDirectory(false);
-			e.setName(key.substring(Math.max(0, key.lastIndexOf("/") + 1)));
-			e.setSize(this.getSize(response));
-			e.setModified(new Date());
-			e.setChecksum(this.getChecksum(response));
-			e.setContentType(this.getType(response));
-			return e;
+			try (HTTPResponse response = WS.url(this.getUrl(key)).get()) {
+				RepoEntry e = new RepoEntry();
+				e.setDirectory(false);
+				e.setName(key.substring(Math.max(0, key.lastIndexOf("/") + 1)));
+				e.setSize(this.getSize(response));
+				e.setModified(new Date());
+				e.setChecksum(this.getChecksum(response));
+				e.setContentType(this.getType(response));
+				return e;
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
HTTPResponses and referring InputStreams should be closed when indexing repositories because number of connections per host is limited.