### PR TITLE
Fix deleting global section of configuration templates

### DIFF
--- a/src/main/java/de/cinovo/cloudconductor/server/rest/shared/ConfigValueImpl.java
+++ b/src/main/java/de/cinovo/cloudconductor/server/rest/shared/ConfigValueImpl.java
@@ -223,7 +223,13 @@ public class ConfigValueImpl implements IConfigValue {
 		RESTAssert.assertNotEmpty(template);
 		RESTAssert.assertNotEmpty(service);
 		
-		this.configValueDAO.findBy(template, service).forEach(cv -> this.configValueDAO.delete(cv));
+		List<EConfigValue> configsToDelete;
+		if (ConfigValueDAOHib.RESERVED_GLOBAL.equals(service)) {
+			configsToDelete = this.configValueDAO.findForGlobalService(template);
+		} else {
+			configsToDelete = this.configValueDAO.findBy(template, service);
+		}
+		configsToDelete.forEach(cv -> this.configValueDAO.delete(cv));
 	}
 	
 	@Override

--- a/src/main/webapp/src/app/configvalues/cv.overview.comp.html
+++ b/src/main/webapp/src/app/configvalues/cv.overview.comp.html
@@ -47,7 +47,7 @@
 
 <div class="row" *ngIf="kvLoaded && tree.length < 1">
   <div class="col-sm-12">
-    <div class="alert alert-warning" role="alert-1">
+    <div class="alert alert-warning" role="alert">
       No key-value pairs found for this template
     </div>
   </div>
@@ -63,7 +63,7 @@
       <li cc-panel-dropdown>
         <a href="javascript:void(0)" mwlConfirmationPopover
            [title]="'Please verify!'"
-           [message]="'Are you sure you want to delete all key-value-pairs for the following service: <strong>' + service.name + '</strong>?'"
+           [message]="'Are you sure you want to delete all key-value pairs for the following service: <strong>' + (service.name || 'GLOBAL') + '</strong>?'"
            confirmButtonType="danger"
            (confirm)="deleteService(service.name)"
            [appendToBody]="true">
@@ -86,15 +86,17 @@
               {{kv.key}}
             </td>
             <td class="word-break">
-              <cc-inlineedit [value]="kv.value" (onSave)="save(kv, $event)"
+              <cc-inlineedit [value]="kv.value"
                              [editMode]="edit[kv.service + kv.key]"
-                             (onEditDone)="triggerEditDone(kv)"></cc-inlineedit>
+                             (onSave)="save(kv, $event)"
+                             (onEditDone)="triggerEditDone(kv)">
+              </cc-inlineedit>
             </td>
             <td>
               <a href="javascript:void(0)" mwlConfirmationPopover
                  title="Delete Pair"
                  [title]="'Please verify!'"
-                 [message]="'Are you sure you want to delete the following key-value-pair: \'' + kv.key + '\'?'"
+                 [message]="'Are you sure you want to delete the following key-value pair: \'' + kv.key + '\'?'"
                  placement="left"
                  confirmButtonType="danger"
                  (confirm)="doDelete(kv)">

--- a/src/main/webapp/src/app/configvalues/cv.overview.comp.ts
+++ b/src/main/webapp/src/app/configvalues/cv.overview.comp.ts
@@ -1,7 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
 import { ConfigValue, ConfigValueHttpService } from '../util/http/configValue.http.service';
@@ -17,8 +16,12 @@ import { AlertService } from '../util/alert/alert.service';
  */
 interface ConfigValueTreeNode {
   name: string;
-  kvs: Array<ConfigValue>;
+  kvs: ConfigValue[];
   icon: string;
+}
+
+interface ServiceConfigMap {
+  [serviceName: string]: ConfigValue[];
 }
 
 @Component({
@@ -29,26 +32,12 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
 
   private _searchQuery: string = null;
   private routeSub: Subscription;
+  private allCVs: ConfigValue[] = [];
 
   public template: string;
   public kvLoaded = false;
-  public edit: Array<boolean> = [];
-  public tree: Array<ConfigValueTreeNode> = [];
-
-  private filterData(cf: ConfigValue, query: string): boolean {
-    if (cf.service == "VARIABLES") {
-      return true;
-    }
-    if (Validator.notEmpty(query)) {
-      for (let field in cf) {
-        if (cf[field].indexOf(query.trim()) >= 0) {
-          return false;
-        }
-      }
-      return true;
-    }
-    return false;
-  }
+  public edit: boolean[] = [];
+  public tree: ConfigValueTreeNode[] = [];
 
   constructor(private configHttp: ConfigValueHttpService,
               private route: ActivatedRoute,
@@ -75,7 +64,17 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
 
   set searchQuery(value: string) {
     this._searchQuery = value;
-    this.loadData();
+    this.tree = this.generateTree();
+  }
+
+  private filterData(configValue: ConfigValue): boolean {
+    if (configValue.service === "VARIABLES") {
+      return false;
+    }
+    if (!Validator.notEmpty(this._searchQuery)) {
+      return true;
+    }
+    return Object.values(configValue).some(value => typeof value === "string" && value.includes(this._searchQuery.trim()))
   }
 
   protected deleteCurrentTemplate(): void {
@@ -83,6 +82,7 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
       .subscribe(
         () => {
           this.alerts.success(`All config values for template '${this.template}' were deleted successfully!`);
+          // noinspection JSIgnoredPromiseFromCall
           this.router.navigate(['config']);
         },
         (err) => {
@@ -93,6 +93,9 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
   }
 
   protected deleteService(serviceName: string): void {
+    if (!serviceName || serviceName.length < 1) {
+      serviceName = "GLOBAL";
+    }
     this.configHttp.deleteForService(this.template, serviceName)
       .subscribe(
         () => {
@@ -120,23 +123,7 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
   }
 
   private doDelete(kv: ConfigValue) {
-    this.deleteKey(kv).subscribe(
-      () => {
-        let element: ConfigValueTreeNode;
-        for (let nodeIndex in this.tree) {
-          if (this.tree[nodeIndex].name === kv.service) {
-            element = this.tree[nodeIndex];
-          }
-        }
-        for (let i in element.kvs) {
-          if (element.kvs[i].key === kv.key) {
-            element.kvs.splice(+i, 1);
-          }
-        }
-        if (element.kvs.length < 1) {
-          this.tree.splice(this.tree.indexOf(element), 1);
-        }
-      },
+    this.configHttp.deleteValue(kv).subscribe(() => this.loadData(),
       (err) => {
         this.alerts.danger(`Error deleting config pair '${kv.key}'-'${kv.value}'!`);
         console.error(err);
@@ -144,64 +131,51 @@ export class ConfigValueOverview implements OnInit, OnDestroy {
     );
   }
 
-  private deleteKey(kv: ConfigValue): Observable<boolean> {
-    return this.configHttp.deleteValue(kv);
+  private generateTree(): ConfigValueTreeNode[] {
+    const tmpServiceConfigMap: ServiceConfigMap = this.allCVs
+      .filter(this.filterData.bind(this))
+      .reduce((serviceMap , currentCV) => {
+        const serviceName = currentCV.service || '';
+        if (!serviceMap[serviceName]) {
+          serviceMap[serviceName] = [];
+        }
+        serviceMap[serviceName].push(currentCV);
+        return serviceMap
+      }, <ServiceConfigMap>{});
+
+    return Object.entries(tmpServiceConfigMap)
+      .map(([name, cvs]) => <ConfigValueTreeNode>{name, kvs: cvs.sort(Sorter.configValue), icon: ConfigValueOverview.getIcon(name)})
+      .sort(Sorter.nameField);
   }
 
-  private generateTree(result: Array<ConfigValue>): void {
-    let temp: { [name: string]: Array<ConfigValue>; } = {};
-    for (let cf of result) {
-      if (this.filterData(cf, this._searchQuery)) {
-        continue;
-      }
-      if (!cf.service) {
-        cf.service = '';
-      }
-      if (!temp[cf.service]) {
-        temp[cf.service] = [];
-      }
-      temp[cf.service].push(cf);
-    }
-
-    this.tree = [];
-    for (let key in temp) {
-      if (temp.hasOwnProperty(key)) {
-        temp[key] = temp[key].sort(Sorter.configValue);
-        this.tree.push({name: key, kvs: temp[key], icon: key.trim() === '' ? 'fa-institution' : 'fa-flask'});
-      }
-    }
-
-    this.tree = this.tree.sort(Sorter.nameField);
+  private static getIcon(name: string): string{
+    const globalIcon = 'fa-institution';
+    const serviceIcon = 'fa-flask';
+    return name.length === 0 ? globalIcon : serviceIcon
   }
 
-  private loadData() {
-    this.configHttp.getValues(this.template).subscribe((result) => {
-      this.generateTree(result);
-      this.kvLoaded = true;
-    }, (err) => {
-      this.alerts.danger(`Error loading config values for template '${this.template}'!`);
-      console.error(err);
-      this.kvLoaded = true;
-    });
+  private loadData(): void {
+    this.configHttp.getValues(this.template)
+      .finally(() => this.kvLoaded = true)
+      .subscribe(
+        (result) => {
+          this.allCVs = result;
+          this.tree = this.generateTree()
+        }, (err) => {
+          this.alerts.danger(`Error loading config values for template '${this.template}'!`);
+          console.error(err);
+        });
   }
 
-  protected goToDetail(cv: ConfigValue) {
-    if (cv) {
-      this.router.navigate(['config', cv.template, cv.service, cv.key]);
-    }
-  }
-
-  protected save(kv: ConfigValue, event: any) {
+  public save(kv: ConfigValue, newVal: any): void {
     const oldVal = kv.value;
-    kv.value = event;
-    this.configHttp.save(kv).subscribe((success) => {
-        this.alerts.success('Modified value for key : ' + kv.key);
-      }, (err) => {
+    kv.value = newVal;
+    this.configHttp.save(kv).subscribe(() => this.alerts.success(`Modified value for key '${kv.key}'`),
+      (err) => {
         kv.value = oldVal;
-        this.alerts.success('Failed to modify value for key : ' + kv.key);
+        this.alerts.success(`Failed to modify value for key '${kv.key}'`);
         console.error(err);
-      }
-    );
+      });
   }
 
 }

--- a/src/main/webapp/src/app/util/http/configValue.http.service.ts
+++ b/src/main/webapp/src/app/util/http/configValue.http.service.ts
@@ -70,8 +70,7 @@ export class ConfigValueHttpService {
   }
 
   public save(val: ConfigValue): Observable<ConfigValue> {
-    val['@class'] = 'de.cinovo.cloudconductor.api.model.ConfigValue';
-    let ret = this.http.put<ConfigValue>(this._basePathURL, val).share();
+    const ret = this.http.put<ConfigValue>(this._basePathURL, {'@class': 'de.cinovo.cloudconductor.api.model.ConfigValue', ...val}).share();
     ret.subscribe(() => this.reloadTemplates(), () => {});
     return ret;
   }
@@ -118,7 +117,7 @@ export class ConfigValueHttpService {
   }
 
   public getPreview(template: string, service: string, mode: string): Observable<any> {
-    let options = {};
+    let options;
     if (mode.indexOf('json') > 0) {
       options = {headers: new HttpHeaders({'Accept': mode})};
     } else {


### PR DESCRIPTION
Delete action on the global section of a configuration template now only removes values from this section and does not touch service specific configurations.